### PR TITLE
feat: Parse PHP 8 features in NamespaceResolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ php-parser [flags] <path> ...
 Namespace resolver
 ------------------
 
-Namespace resolver is a visitor that resolves nodes fully qualified name and saves into `map[node.Node]string` structure
+Namespace resolver is a visitor that resolves nodes fully qualified name and saves into `map[ast.Vertex]string` structure
 
-- For `Class`, `Interface`, `Trait`, `Function`, `Constant` nodes it saves name with current namespace.
+- For `Class`, `Interface`, `Trait`, `Enum`, `Function`, `Constant` nodes it saves name with current namespace.
 - For `Name`, `Relative`, `FullyQualified` nodes it resolves `use` aliases and saves a fully qualified name.

--- a/pkg/visitor/nsresolver/namespace_resolver.go
+++ b/pkg/visitor/nsresolver/namespace_resolver.go
@@ -278,6 +278,12 @@ func (nsr *NamespaceResolver) ResolveType(n ast.Vertex) {
 	switch nn := n.(type) {
 	case *ast.Nullable:
 		nsr.ResolveType(nn.Expr)
+
+	case *ast.Union:
+		for _, nnn := range nn.Types {
+			nsr.ResolveType(nnn)
+		}
+
 	case *ast.Name:
 		nsr.ResolveName(n, "")
 	case *ast.NameRelative:

--- a/pkg/visitor/nsresolver/namespace_resolver.go
+++ b/pkg/visitor/nsresolver/namespace_resolver.go
@@ -370,6 +370,8 @@ func (ns *Namespace) ResolveName(nameNode ast.Vertex, aliasType string) (string,
 			case "iterable":
 				fallthrough
 			case "object":
+				fallthrough
+			case "mixed": // 8.0
 				return part, nil
 			}
 		}

--- a/pkg/visitor/nsresolver/namespace_resolver.go
+++ b/pkg/visitor/nsresolver/namespace_resolver.go
@@ -372,6 +372,8 @@ func (ns *Namespace) ResolveName(nameNode ast.Vertex, aliasType string) (string,
 			case "object":
 				fallthrough
 			case "mixed": // 8.0
+				fallthrough
+			case "never": // 8.1
 				return part, nil
 			}
 		}

--- a/pkg/visitor/nsresolver/namespace_resolver.go
+++ b/pkg/visitor/nsresolver/namespace_resolver.go
@@ -89,6 +89,22 @@ func (nsr *NamespaceResolver) StmtClass(n *ast.StmtClass) {
 	}
 }
 
+func (nsr *NamespaceResolver) StmtEnum(n *ast.StmtEnum) {
+	if n.Type != nil {
+		nsr.ResolveName(n.Type, "")
+	}
+
+	if n.Implements != nil {
+		for _, interfaceName := range n.Implements {
+			nsr.ResolveName(interfaceName, "")
+		}
+	}
+
+	if n.Name != nil {
+		nsr.AddNamespacedName(n, string(n.Name.(*ast.Identifier).Value))
+	}
+}
+
 func (nsr *NamespaceResolver) StmtInterface(n *ast.StmtInterface) {
 	if n.Extends != nil {
 		for _, interfaceName := range n.Extends {

--- a/pkg/visitor/nsresolver/namespace_resolver.go
+++ b/pkg/visitor/nsresolver/namespace_resolver.go
@@ -283,6 +283,10 @@ func (nsr *NamespaceResolver) ResolveType(n ast.Vertex) {
 		for _, nnn := range nn.Types {
 			nsr.ResolveType(nnn)
 		}
+	case *ast.Intersection:
+		for _, nnn := range nn.Types {
+			nsr.ResolveType(nnn)
+		}
 
 	case *ast.Name:
 		nsr.ResolveName(n, "")

--- a/pkg/visitor/nsresolver/namespace_resolver.go
+++ b/pkg/visitor/nsresolver/namespace_resolver.go
@@ -374,6 +374,8 @@ func (ns *Namespace) ResolveName(nameNode ast.Vertex, aliasType string) (string,
 			case "mixed": // 8.0
 				fallthrough
 			case "never": // 8.1
+				fallthrough
+			case "true", "false", "null": // 8.2
 				return part, nil
 			}
 		}

--- a/pkg/visitor/nsresolver/namespace_resolver.go
+++ b/pkg/visitor/nsresolver/namespace_resolver.go
@@ -222,6 +222,10 @@ func (nsr *NamespaceResolver) StmtTraitUse(n *ast.StmtTraitUse) {
 	}
 }
 
+func (nsr *NamespaceResolver) Attribute(n *ast.Attribute) {
+	nsr.ResolveName(n.Name, "")
+}
+
 // LeaveNode is invoked after node process
 func (nsr *NamespaceResolver) LeaveNode(n ast.Vertex) {
 	switch nn := n.(type) {

--- a/pkg/visitor/nsresolver/namespace_resolver_test.go
+++ b/pkg/visitor/nsresolver/namespace_resolver_test.go
@@ -861,6 +861,12 @@ func TestDoNotResolveReservedNames(t *testing.T) {
 		},
 	}
 
+	nameNever := &ast.Name{
+		Parts: []ast.Vertex{
+			&ast.NamePart{Value: []byte("never")},
+		},
+	}
+
 	function := &ast.StmtFunction{
 		Name: &ast.Identifier{Value: []byte("bar")},
 		Params: []ast.Vertex{
@@ -912,6 +918,12 @@ func TestDoNotResolveReservedNames(t *testing.T) {
 					Name: &ast.Identifier{Value: []byte("Mixed")},
 				},
 			},
+			&ast.Parameter{
+				Type: nameNever,
+				Var: &ast.ExprVariable{
+					Name: &ast.Identifier{Value: []byte("Never")},
+				},
+			},
 		},
 	}
 
@@ -938,6 +950,7 @@ func TestDoNotResolveReservedNames(t *testing.T) {
 		nameIterable: "iterable",
 		nameObject:   "object",
 		nameMixed:    "mixed",
+		nameNever:    "never",
 	}
 
 	nsResolver := nsresolver.NewNamespaceResolver()

--- a/pkg/visitor/nsresolver/namespace_resolver_test.go
+++ b/pkg/visitor/nsresolver/namespace_resolver_test.go
@@ -542,6 +542,8 @@ func TestResolveMethodName(t *testing.T) {
 	nameBC := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("B")}, &ast.NamePart{Value: []byte("C")}}}
 	nameCD := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("C")}, &ast.NamePart{Value: []byte("D")}}}
 	nameDE := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("D")}, &ast.NamePart{Value: []byte("E")}}}
+	nameEF := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("E")}, &ast.NamePart{Value: []byte("F")}}}
+	nameFG := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("F")}, &ast.NamePart{Value: []byte("G")}}}
 
 	methodNode := &ast.StmtClassMethod{
 		Name: &ast.Identifier{Value: []byte("A")},
@@ -553,6 +555,10 @@ func TestResolveMethodName(t *testing.T) {
 			&ast.Parameter{
 				Type: &ast.Union{Types: []ast.Vertex{nameCD, nameDE}},
 				Var:  &ast.ExprVariable{Name: &ast.Identifier{Value: []byte("all")}},
+			},
+			&ast.Parameter{
+				Type: &ast.Intersection{Types: []ast.Vertex{nameEF, nameFG}},
+				Var:  &ast.ExprVariable{Name: &ast.Identifier{Value: []byte("any")}},
 			},
 		},
 		ReturnType: &ast.Nullable{Expr: nameBC},
@@ -566,6 +572,8 @@ func TestResolveMethodName(t *testing.T) {
 		nameBC: "B\\C",
 		nameCD: "C\\D",
 		nameDE: "D\\E",
+		nameEF: "E\\F",
+		nameFG: "F\\G",
 	}
 
 	nsResolver := nsresolver.NewNamespaceResolver()

--- a/pkg/visitor/nsresolver/namespace_resolver_test.go
+++ b/pkg/visitor/nsresolver/namespace_resolver_test.go
@@ -385,12 +385,20 @@ func TestResolveTraitUse(t *testing.T) {
 func TestResolveClassName(t *testing.T) {
 	nameAB := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("A")}, &ast.NamePart{Value: []byte("B")}}}
 	nameBC := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("B")}, &ast.NamePart{Value: []byte("C")}}}
+	nameCD := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("C")}, &ast.NamePart{Value: []byte("D")}}}
 
 	class := &ast.StmtClass{
 		Name:    &ast.Identifier{Value: []byte("A")},
 		Extends: nameAB,
 		Implements: []ast.Vertex{
 			nameBC,
+		},
+		AttrGroups: []ast.Vertex{
+			&ast.AttributeGroup{
+				Attrs: []ast.Vertex{
+					&ast.Attribute{Name: nameCD},
+				},
+			},
 		},
 	}
 
@@ -404,6 +412,7 @@ func TestResolveClassName(t *testing.T) {
 		class:  "A",
 		nameAB: "A\\B",
 		nameBC: "B\\C",
+		nameCD: "C\\D",
 	}
 
 	nsResolver := nsresolver.NewNamespaceResolver()
@@ -629,6 +638,19 @@ func TestResolveNamespaces(t *testing.T) {
 	nameFG := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("F")}, &ast.NamePart{Value: []byte("G")}}}
 	relativeNameCE := &ast.NameRelative{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("C")}, &ast.NamePart{Value: []byte("E")}}}
 
+	relativeNameCA := &ast.NameRelative{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("C")}, &ast.NamePart{Value: []byte("A")}}}
+
+	classA := &ast.StmtClass{
+		Name: &ast.Identifier{Value: []byte("A")},
+		AttrGroups: []ast.Vertex{
+			&ast.AttributeGroup{
+				Attrs: []ast.Vertex{
+					&ast.Attribute{Name: relativeNameCA},
+				},
+			},
+		},
+	}
+
 	constantB := &ast.StmtConstant{
 		Name: &ast.Identifier{Value: []byte("B")},
 		Expr: &ast.ScalarLnumber{Value: []byte("1")},
@@ -643,6 +665,9 @@ func TestResolveNamespaces(t *testing.T) {
 			&ast.StmtNamespace{
 				Name: namespaceAB,
 			},
+
+			classA,
+
 			&ast.StmtConstList{
 				Consts: []ast.Vertex{
 					constantB,
@@ -653,6 +678,7 @@ func TestResolveNamespaces(t *testing.T) {
 				Class: nameFG,
 				Call:  &ast.Identifier{Value: []byte("foo")},
 			},
+
 			&ast.StmtNamespace{
 				Stmts: []ast.Vertex{},
 			},
@@ -680,6 +706,8 @@ func TestResolveNamespaces(t *testing.T) {
 	}
 
 	expected := map[ast.Vertex]string{
+		classA:         "A\\B\\A",
+		relativeNameCA: "A\\B\\C\\A",
 		constantB:      "A\\B\\B",
 		constantC:      "A\\B\\C",
 		nameFG:         "A\\B\\F\\G",

--- a/pkg/visitor/nsresolver/namespace_resolver_test.go
+++ b/pkg/visitor/nsresolver/namespace_resolver_test.go
@@ -540,6 +540,8 @@ func TestResolveFunctionName(t *testing.T) {
 func TestResolveMethodName(t *testing.T) {
 	nameAB := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("A")}, &ast.NamePart{Value: []byte("B")}}}
 	nameBC := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("B")}, &ast.NamePart{Value: []byte("C")}}}
+	nameCD := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("C")}, &ast.NamePart{Value: []byte("D")}}}
+	nameDE := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("D")}, &ast.NamePart{Value: []byte("E")}}}
 
 	methodNode := &ast.StmtClassMethod{
 		Name: &ast.Identifier{Value: []byte("A")},
@@ -547,6 +549,10 @@ func TestResolveMethodName(t *testing.T) {
 			&ast.Parameter{
 				Type: nameAB,
 				Var:  &ast.ExprVariable{Name: &ast.Identifier{Value: []byte("foo")}},
+			},
+			&ast.Parameter{
+				Type: &ast.Union{Types: []ast.Vertex{nameCD, nameDE}},
+				Var:  &ast.ExprVariable{Name: &ast.Identifier{Value: []byte("all")}},
 			},
 		},
 		ReturnType: &ast.Nullable{Expr: nameBC},
@@ -558,6 +564,8 @@ func TestResolveMethodName(t *testing.T) {
 	expected := map[ast.Vertex]string{
 		nameAB: "A\\B",
 		nameBC: "B\\C",
+		nameCD: "C\\D",
+		nameDE: "D\\E",
 	}
 
 	nsResolver := nsresolver.NewNamespaceResolver()

--- a/pkg/visitor/nsresolver/namespace_resolver_test.go
+++ b/pkg/visitor/nsresolver/namespace_resolver_test.go
@@ -867,6 +867,24 @@ func TestDoNotResolveReservedNames(t *testing.T) {
 		},
 	}
 
+	nameTrue := &ast.Name{
+		Parts: []ast.Vertex{
+			&ast.NamePart{Value: []byte("true")},
+		},
+	}
+
+	nameFalse := &ast.Name{
+		Parts: []ast.Vertex{
+			&ast.NamePart{Value: []byte("false")},
+		},
+	}
+
+	nameNull := &ast.Name{
+		Parts: []ast.Vertex{
+			&ast.NamePart{Value: []byte("null")},
+		},
+	}
+
 	function := &ast.StmtFunction{
 		Name: &ast.Identifier{Value: []byte("bar")},
 		Params: []ast.Vertex{
@@ -924,6 +942,24 @@ func TestDoNotResolveReservedNames(t *testing.T) {
 					Name: &ast.Identifier{Value: []byte("Never")},
 				},
 			},
+			&ast.Parameter{
+				Type: nameTrue,
+				Var: &ast.ExprVariable{
+					Name: &ast.Identifier{Value: []byte("True")},
+				},
+			},
+			&ast.Parameter{
+				Type: nameFalse,
+				Var: &ast.ExprVariable{
+					Name: &ast.Identifier{Value: []byte("False")},
+				},
+			},
+			&ast.Parameter{
+				Type: nameNull,
+				Var: &ast.ExprVariable{
+					Name: &ast.Identifier{Value: []byte("Null")},
+				},
+			},
 		},
 	}
 
@@ -951,6 +987,9 @@ func TestDoNotResolveReservedNames(t *testing.T) {
 		nameObject:   "object",
 		nameMixed:    "mixed",
 		nameNever:    "never",
+		nameTrue:     "true",
+		nameFalse:    "false",
+		nameNull:     "null",
 	}
 
 	nsResolver := nsresolver.NewNamespaceResolver()

--- a/pkg/visitor/nsresolver/namespace_resolver_test.go
+++ b/pkg/visitor/nsresolver/namespace_resolver_test.go
@@ -855,6 +855,12 @@ func TestDoNotResolveReservedNames(t *testing.T) {
 		},
 	}
 
+	nameMixed := &ast.Name{
+		Parts: []ast.Vertex{
+			&ast.NamePart{Value: []byte("mixed")},
+		},
+	}
+
 	function := &ast.StmtFunction{
 		Name: &ast.Identifier{Value: []byte("bar")},
 		Params: []ast.Vertex{
@@ -900,6 +906,12 @@ func TestDoNotResolveReservedNames(t *testing.T) {
 					Name: &ast.Identifier{Value: []byte("Object")},
 				},
 			},
+			&ast.Parameter{
+				Type: nameMixed,
+				Var: &ast.ExprVariable{
+					Name: &ast.Identifier{Value: []byte("Mixed")},
+				},
+			},
 		},
 	}
 
@@ -925,6 +937,7 @@ func TestDoNotResolveReservedNames(t *testing.T) {
 		nameVoid:     "void",
 		nameIterable: "iterable",
 		nameObject:   "object",
+		nameMixed:    "mixed",
 	}
 
 	nsResolver := nsresolver.NewNamespaceResolver()

--- a/pkg/visitor/nsresolver/namespace_resolver_test.go
+++ b/pkg/visitor/nsresolver/namespace_resolver_test.go
@@ -1,9 +1,10 @@
 package nsresolver_test
 
 import (
+	"testing"
+
 	"github.com/laytan/php-parser/pkg/visitor/nsresolver"
 	"github.com/laytan/php-parser/pkg/visitor/traverser"
-	"testing"
 
 	"gotest.tools/assert"
 
@@ -455,6 +456,36 @@ func TestResolveTraitName(t *testing.T) {
 
 	expected := map[ast.Vertex]string{
 		traitNode: "A",
+	}
+
+	nsResolver := nsresolver.NewNamespaceResolver()
+	traverser.NewTraverser(nsResolver).Traverse(stxTree)
+
+	assert.DeepEqual(t, expected, nsResolver.ResolvedNames)
+}
+
+func TestResolveEnumName(t *testing.T) {
+	nameAB := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("A")}, &ast.NamePart{Value: []byte("B")}}}
+	nameBC := &ast.Name{Parts: []ast.Vertex{&ast.NamePart{Value: []byte("B")}, &ast.NamePart{Value: []byte("C")}}}
+
+	enum := &ast.StmtEnum{
+		Name: &ast.Identifier{Value: []byte("A")},
+		Type: nameAB,
+		Implements: []ast.Vertex{
+			nameBC,
+		},
+	}
+
+	stxTree := &ast.StmtStmtList{
+		Stmts: []ast.Vertex{
+			enum,
+		},
+	}
+
+	expected := map[ast.Vertex]string{
+		enum:   "A",
+		nameAB: "A\\B",
+		nameBC: "B\\C",
 	}
 
 	nsResolver := nsresolver.NewNamespaceResolver()


### PR DESCRIPTION
This PR extends the `pkg/visitor/nsresolver.NamespaceResolver` type with proper awareness of certain features from PHP 8.0 - 8.2 that affect namespacing resolution. In particular:

- `Enum`
- `Attribute`
- Union (`A | B`) and intersection (`A & B`) types
- The reserved types `mixed`, `never`, `true`, `false`, `null`

Tests for the new resolution behavior are provided.